### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main", "develop" ]
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nicoloverardo/matrix_regression/security/code-scanning/3](https://github.com/nicoloverardo/matrix_regression/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yaml` so all jobs inherit least-privilege defaults.  
Best single change (without altering workflow behavior): add

```yaml
permissions:
  contents: read
```

right after the `on:` section (before `jobs:`). This satisfies CodeQL’s minimal recommendation and keeps behavior intact for checkout/lint/test flows.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
