### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nicoloverardo/matrix_regression/security/code-scanning/1](https://github.com/nicoloverardo/matrix_regression/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/publish.yml` at the workflow root so it applies to all jobs (currently just `publish`).  
The least-privilege setting for the shown steps is:

- `contents: read` (needed for `actions/checkout` to read repository contents)

No additional scopes are required for publishing to PyPI here because that uses `UV_PUBLISH_TOKEN` from `secrets.PYPI_API_TOKEN`, not `GITHUB_TOKEN`.

Edit region: directly after the `on:` trigger section and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
